### PR TITLE
moment.js publishedAt parse

### DIFF
--- a/src/services/main.js
+++ b/src/services/main.js
@@ -3,6 +3,7 @@ import * as moment from 'moment';
 const formatPublish = (publishedAt) => {
     // publishedAt needs to be a string
     // example: "2019-02-08T16:09:24.000Z"
+    // how to access response.data.items[i].snippet.publishedAt
     if(typeof publishedAt !== 'string') return 'Publish Date Error';
     const published = moment(publishedAt, 'YYYY-MM-DD')
     return moment(published).fromNow()


### PR DESCRIPTION
Added a function to main.js that takes in a published date string from the YouTubeAPI and returns the elapse time since it was published.

Example: 
`formatPublish('2019-02-08T16:09:24.000Z') // 2 days ago`